### PR TITLE
updated job_start options to allow job to finish

### DIFF
--- a/autoload/validator.vim
+++ b/autoload/validator.vim
@@ -107,7 +107,7 @@ function! s:check()
       let written = v:true
     endif
     let in_io = stdin ? 'pipe' : 'null'
-    let job = job_start(cmd, {"close_cb": s:gen_handler(ft, nr, checker), "in_io": in_io, "err_io": 'out'})
+    let job = job_start(cmd, {"close_cb": s:gen_handler(ft, nr, checker), "in_io": in_io, "err_io": 'out', "stoponexit": ""})
     if stdin
       call s:send_buffer(job, lines)
     endif


### PR DESCRIPTION
The validator.vim plugin causes a segfault if a file is being validated
at the time :wq is run. Tracing the issue appears to the show the
SIGSEGV occurs when new_threadstate is called from the Python libraries.
My rough suspicion is that the SIGTERM sent to the linter (itself
running Python) may be cause. Preventing the SIGTERM is what this
commit does, which resolves maralla/validator.vim#53.